### PR TITLE
Project Stability & Bug Fixes

### DIFF
--- a/Aion.Components/Querying/QueryEditor.razor
+++ b/Aion.Components/Querying/QueryEditor.razor
@@ -193,13 +193,13 @@
     {
         if (_editor != null)
         {
-            await _editor.SetValue(State.Active.Query);
+            await _editor.SetValue(State?.Active?.Query ?? "");
         }
     }
 
     private async Task UpdateQuery(ModelContentChangedEvent evt)
     {
-        if (!_initialized) return;
+        if (!_initialized || State.Active == null) return;
         
         var text = await _editor.GetValue();
         State.Active.Query = text;

--- a/Aion.Components/Querying/QueryState.cs
+++ b/Aion.Components/Querying/QueryState.cs
@@ -102,7 +102,7 @@ public class QueryState : IConsumer<QueryChanged>
 
     public void SetActive(QueryModel query)
     {
-        Active = Queries.FirstOrDefault(x => x.Id.Equals(query.Id));
+        Active = Queries.FirstOrDefault(x => x.Id.Equals(query?.Id));
 
         if (Active == null) return;
 

--- a/Aion.Desktop/Aion.Desktop.csproj
+++ b/Aion.Desktop/Aion.Desktop.csproj
@@ -28,9 +28,9 @@
     </ItemGroup>
 
     <ItemGroup>
-      <None Update="wwwroot\**">
+      <Content Update="wwwroot\**">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </None>
+      </Content>
     </ItemGroup>
 
     <ItemGroup>

--- a/Aion.Test/Components/Querying/QueryEditorTests.cs
+++ b/Aion.Test/Components/Querying/QueryEditorTests.cs
@@ -1,0 +1,66 @@
+using Aion.Components.Connections;
+using Aion.Components.Infrastructure.MessageBus;
+using Aion.Components.Querying;
+using Aion.Core.Database;
+using Bunit;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using MudBlazor.Interop;
+using MudBlazor.Services;
+using NSubstitute;
+using Shouldly;
+
+namespace Aion.Test.Components.Querying;
+
+public class QueryEditorTests : TestContext
+{
+    private QueryState _state;
+    private ConnectionState _connections;
+    private IMessageBus _bus;
+    
+    public QueryEditorTests()
+    {
+        Services.AddLogging();
+        Services.AddMudServices(x =>
+        {
+            x.PopoverOptions.CheckForPopoverProvider = false;
+        });
+        JSInterop.SetupVoid("mudPopover.initialize", _ => true);
+        JSInterop.SetupVoid("mudPopover.connect", _ => true);
+        JSInterop.SetupVoid("mudKeyInterceptor.connect", _ => true);
+        JSInterop.Setup<BoundingClientRect[]>("mudResizeObserver.connect", _ => true);
+        JSInterop.SetupVoid("blazorMonaco.editor.setWasm", false);
+        
+        _bus = new InMemoryMessageBus(this.Services, new NullLogger<InMemoryMessageBus>());
+        _state = new(_bus, NSubstitute.Substitute.For<IQuerySaveService>());
+        _connections = new ConnectionState(Substitute.For<IConnectionService>(), Substitute.For<IDatabaseProviderFactory>(), _bus, new NullLogger<ConnectionState>());
+        Services.AddSingleton(_bus);
+        Services.AddSingleton(_state);
+        Services.AddSingleton(_connections);
+    }
+
+    [Fact]
+    public void Can_Render_QueryEditor()
+    {
+        // Arrange & Act
+        var cut = RenderComponent<QueryEditor>();
+        
+        // Assert
+        cut.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void Can_Render_WithNullActiveQuery()
+    {
+        // Arrange
+        _state.SetActive(null!);
+        
+        // Act
+        var cut = RenderComponent<QueryEditor>();
+        
+        // Assert
+        cut.ShouldNotBeNull();
+        
+    }
+}


### PR DESCRIPTION
 - Try to ensure wwwroot always gets copied as content to prevent build errors with empty bin
 - Clean up a couple of places where a null reference could occur (first load without loading any queries from memory/file)
 - Add unit test for basic rendering validation of QueryEditor
   - Future, error boundary around the monaco piece to further isolate the JS stuff?

Resolves #35 