### PR TITLE
Include some helpful support links

### DIFF
--- a/Aion.Components/Infrastructure/ILinkOpenService.cs
+++ b/Aion.Components/Infrastructure/ILinkOpenService.cs
@@ -1,0 +1,6 @@
+namespace Aion.Components.Infrastructure;
+
+public interface ILinkOpenService
+{
+    public void OpenUrl(string url);
+}

--- a/Aion.Components/Shared/Dialogs/HelpDialog.razor
+++ b/Aion.Components/Shared/Dialogs/HelpDialog.razor
@@ -1,6 +1,8 @@
 @using System.Reflection
+@using Aion.Components.Infrastructure
 @using Aion.Components.Shared
 @using Aion.Components.Theme
+@using Microsoft.JSInterop
 
 <MudDialog Class="aion-transparent-dialog about-aion-dialog">
     <DialogContent>
@@ -18,7 +20,9 @@
         </MudGrid>
     </DialogContent>
     <DialogActions>
-        <MudLink Href="https://wwww.mythetech.com" Class="app-header-font">Mythetech</MudLink>
+        <MudLink OnClick="OpenMythetech" Class="app-header-font">Mythetech</MudLink>
+        <MudLink OnClick="OpenGithub">GitHub</MudLink>
+        <AionIconButton OnClick="@OpenGithubIssues" Size="Size.Small" Color="Color.Error" Tooltip="Report Issue" Icon="@AionIcons.Round("bug_report")" />
         <MudSpacer/>
         <MudButton OnClick="Cancel">Close</MudButton>
     </DialogActions>
@@ -27,6 +31,25 @@
     [CascadingParameter]
     private IMudDialogInstance MudDialog { get; set; }
     private void Cancel() => MudDialog.Cancel();
+    private const string GitHubLink = "https://github.com/Mythetech/Aion/";
+    private const string GitHubIssuesLink = $"{GitHubLink}issues/new";
+    private const string MythetechLink = "https://www.mythetech.com";
 
+    private void OpenMythetech()
+    {
+        LinkOpenService.OpenUrl(MythetechLink);
+    }
+
+    private void OpenGithub()
+    {
+        LinkOpenService.OpenUrl(GitHubLink);
+    }
+    
+    private void OpenGithubIssues()
+    {
+        LinkOpenService.OpenUrl(GitHubIssuesLink);
+    }
+
+    [Inject] ILinkOpenService LinkOpenService { get; set; }
 
 }

--- a/Aion.Desktop/Program.cs
+++ b/Aion.Desktop/Program.cs
@@ -34,6 +34,7 @@ namespace Aion.Desktop
 
             appBuilder.Services.AddSingleton<IPhotinoAppProvider, PhotinoAppProvider>();
             appBuilder.Services.AddTransient<IFileSaveService, PhotinoInteropFileSaveService>();
+            appBuilder.Services.AddTransient<ILinkOpenService, LinkOpenService>();
             
             var app = appBuilder.Build();
 

--- a/Aion.Desktop/Services/LinkOpenService.cs
+++ b/Aion.Desktop/Services/LinkOpenService.cs
@@ -1,0 +1,12 @@
+using System.Diagnostics;
+using Aion.Components.Infrastructure;
+
+namespace Aion.Desktop.Services;
+
+public class LinkOpenService : ILinkOpenService
+{
+    public void OpenUrl(string url)
+    {
+        Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
+    }
+}


### PR DESCRIPTION
 - New link open Services
 - In the context of photino regular links to external domains don't make sense because the app is running in a web view, for desktop .net apps the expected way to handle this is starting a process for the link so it gets handled however by the os (opening in default browser)